### PR TITLE
Fix: SyntaxWarning: "is" with 'int'

### DIFF
--- a/magic/magic.py
+++ b/magic/magic.py
@@ -206,7 +206,7 @@ def errorcheck_null(result, func, args):
         return result
 
 def errorcheck_negative_one(result, func, args):
-    if result is -1:
+    if result == -1:
         err = magic_error(args[0])
         raise MagicException(err)
     else:


### PR DESCRIPTION
SyntaxWarning: "is" with 'int' literal